### PR TITLE
Support loading of nested routes

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -21,7 +21,8 @@ module.exports = {
 	output: {
 		path: path.resolve(__dirname, './build'),
 		filename: '[name].[hash:8].js',
-		chunkFilename: '[id].[hash:8].chunk.js'
+		chunkFilename: '[id].[hash:8].chunk.js',
+                publicPath: '/'
 	},
 
 	resolve: {


### PR DESCRIPTION
Currently nesting of routes more than one level breaks loading of css and js as the route gets added to the path. Adding root as the public path solves this.